### PR TITLE
[FEAT/#21] Week7 / 필수 과제

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id "kotlin-parcelize"
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.20'
+    id 'kotlin-kapt'
 }
 
 Properties properties = new Properties()
@@ -32,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig true

--- a/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
@@ -18,5 +18,5 @@ interface AuthService {
     @POST("api/v1/members/sign-in")
     suspend fun login(
         @Body request: RequestLoginDto,
-    ): Call<ResponseLoginDto>
+    ): ResponseLoginDto
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
@@ -12,7 +12,7 @@ interface AuthService {
     @POST("api/v1/members")
     suspend fun signUp(
         @Body request: RequestSignupDto,
-    ): Call<Unit>
+    )
 
     // 로그인
     @POST("api/v1/members/sign-in")

--- a/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
@@ -10,7 +10,7 @@ import retrofit2.http.POST
 interface AuthService {
     // 회원가입
     @POST("api/v1/members")
-    fun signUp(
+    suspend fun signUp(
         @Body request: RequestSignupDto,
     ): Call<Unit>
 

--- a/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
@@ -16,7 +16,7 @@ interface AuthService {
 
     // 로그인
     @POST("api/v1/members/sign-in")
-    fun login(
+    suspend fun login(
         @Body request: RequestLoginDto,
     ): Call<ResponseLoginDto>
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/data/service/AuthService.kt
@@ -3,7 +3,6 @@ package org.sopt.dosopttemplate.data.service
 import org.sopt.dosopttemplate.data.remote.request.RequestLoginDto
 import org.sopt.dosopttemplate.data.remote.request.RequestSignupDto
 import org.sopt.dosopttemplate.data.remote.response.ResponseLoginDto
-import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/app/src/main/java/org/sopt/dosopttemplate/data/service/PeopleService.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/data/service/PeopleService.kt
@@ -1,7 +1,6 @@
 package org.sopt.dosopttemplate.data.service
 
 import org.sopt.dosopttemplate.data.remote.response.ResponsePeopleListDto
-import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -9,8 +8,8 @@ interface PeopleService {
 
     // 사람들 리스트 받아오기
     @GET("users")
-    fun PeopleListGet(
+    suspend fun PeopleListGet(
         @Query("page") page: Int,
         @Query("per_page") perPage: Int,
-    ): Call<ResponsePeopleListDto>
+    ): ResponsePeopleListDto
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -8,7 +8,6 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.data.User
 import org.sopt.dosopttemplate.databinding.ActivityLoginBinding
 import org.sopt.dosopttemplate.di.UserSharedPreferences
@@ -70,7 +69,32 @@ class LoginActivity : AppCompatActivity() {
                     }
 
                     is UiState.Failure -> {
-                        //showShortSnackBar(binding.root, "로그인 성공, 유저 아이디 : ${loginViewModel.}")
+                        showShortSnackBar(binding.root, "실패")
+                    }
+
+                    is UiState.Loading -> {
+                        showShortSnackBar(binding.root, "로딩중")
+                    }
+                }
+            }
+
+            loginViewModel.getLoginInfo.observe(
+                this,
+            ) { uiState ->
+                when (uiState) {
+                    is UiState.Success -> {
+                        if (binding.cbLoginAutologin.isChecked) {
+                            signUpUser?.let {
+                                loginViewModel.saveUserForAutoLogin(this, it)
+                            }
+                        }
+
+                        val userId = uiState.data?.userId
+                        showShortSnackBar(binding.root, "로그인 성공, 유저 아이디 : $userId")
+                    }
+
+                    is UiState.Failure -> {
+                        showShortSnackBar(binding.root, "실패")
                     }
 
                     is UiState.Loading -> {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -92,6 +92,10 @@ class LoginActivity : AppCompatActivity() {
                     is UiState.Loading -> {
                         showShortSnackBar(binding.root, getString(R.string.uistate_loading))
                     }
+
+                    is UiState.Initial -> {
+                        showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -80,11 +80,7 @@ class LoginActivity : AppCompatActivity() {
 
                         val userId = uiState.data?.userId
                         showShortToast("로그인 성공, 유저 아이디 : $userId")
-
-                        val intent = Intent(this, BnvActivity::class.java)
-                        intent.putExtra("signUpUser", signUpUser)
-                        startActivity(intent)
-                        finish()
+                        goHome(signUpUser)
                     }
 
                     is UiState.Failure -> {
@@ -101,6 +97,13 @@ class LoginActivity : AppCompatActivity() {
                 }
             }.launchIn(lifecycleScope)
         }
+    }
+
+    private fun goHome(signUpUser: User?) {
+        val intent = Intent(this, BnvActivity::class.java)
+        intent.putExtra("signUpUser", signUpUser)
+        startActivity(intent)
+        finish()
     }
 
     private fun backPressed() {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -8,6 +8,10 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.data.User
 import org.sopt.dosopttemplate.databinding.ActivityLoginBinding
@@ -65,9 +69,7 @@ class LoginActivity : AppCompatActivity() {
 
             loginViewModel.loginUser(inputId, inputPw)
 
-            loginViewModel.getLoginInfo.observe(
-                this,
-            ) { uiState ->
+            loginViewModel.getLoginInfo.flowWithLifecycle(lifecycle).onEach { uiState ->
                 when (uiState) {
                     is UiState.Success -> {
                         if (binding.cbLoginAutologin.isChecked) {
@@ -97,7 +99,7 @@ class LoginActivity : AppCompatActivity() {
                         showShortSnackBar(binding.root, getString(R.string.uistate_loading))
                     }
                 }
-            }
+            }.launchIn(lifecycleScope)
         }
     }
 

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -93,7 +93,7 @@ class LoginActivity : AppCompatActivity() {
                     }
 
                     is UiState.Initial -> {
-                        showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                        showShortSnackBar(binding.root, getString(R.string.uistate_initial))
                     }
                 }
             }.launchIn(lifecycleScope)

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -8,6 +8,7 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.data.User
 import org.sopt.dosopttemplate.databinding.ActivityLoginBinding
 import org.sopt.dosopttemplate.di.UserSharedPreferences
@@ -74,11 +75,11 @@ class LoginActivity : AppCompatActivity() {
                     }
 
                     is UiState.Failure -> {
-                        showShortSnackBar(binding.root, "실패")
+                        showShortSnackBar(binding.root, "로그인 실패 : ${uiState.errorMessage}")
                     }
 
                     is UiState.Loading -> {
-                        showShortSnackBar(binding.root, "로딩중")
+                        showShortSnackBar(binding.root, getString(R.string.uistate_loading))
                     }
                 }
             }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -16,6 +16,7 @@ import org.sopt.dosopttemplate.util.BackPressedUtil
 import org.sopt.dosopttemplate.util.UiState
 import org.sopt.dosopttemplate.util.hideKeyboard
 import org.sopt.dosopttemplate.util.showShortSnackBar
+import org.sopt.dosopttemplate.util.showShortToast
 
 class LoginActivity : AppCompatActivity() {
     private lateinit var binding: ActivityLoginBinding
@@ -52,32 +53,6 @@ class LoginActivity : AppCompatActivity() {
 
             loginViewModel.loginUser(inputId, inputPw)
 
-            loginViewModel.loginResult.observe(
-                this,
-            ) { uiState ->
-                when (uiState) {
-                    is UiState.Success -> {
-                        if (binding.cbLoginAutologin.isChecked) {
-                            signUpUser?.let {
-                                loginViewModel.saveUserForAutoLogin(this, it)
-                            }
-                        }
-                        val intent = Intent(this, BnvActivity::class.java)
-                        intent.putExtra("signUpUser", signUpUser)
-                        startActivity(intent)
-                        finish()
-                    }
-
-                    is UiState.Failure -> {
-                        showShortSnackBar(binding.root, "실패")
-                    }
-
-                    is UiState.Loading -> {
-                        showShortSnackBar(binding.root, "로딩중")
-                    }
-                }
-            }
-
             loginViewModel.getLoginInfo.observe(
                 this,
             ) { uiState ->
@@ -90,7 +65,12 @@ class LoginActivity : AppCompatActivity() {
                         }
 
                         val userId = uiState.data?.userId
-                        showShortSnackBar(binding.root, "로그인 성공, 유저 아이디 : $userId")
+                        showShortToast("로그인 성공, 유저 아이디 : $userId")
+
+                        val intent = Intent(this, BnvActivity::class.java)
+                        intent.putExtra("signUpUser", signUpUser)
+                        startActivity(intent)
+                        finish()
                     }
 
                     is UiState.Failure -> {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -27,6 +27,13 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        autoLogin()
+        userClickSignUpBtn()
+        userCickLoginBtn()
+        backPressed()
+    }
+
+    private fun autoLogin() {
         // 자동 로그인으로 저장된 유저 정보
         val spUser = UserSharedPreferences.getUser(this)
 
@@ -37,14 +44,18 @@ class LoginActivity : AppCompatActivity() {
             // 새로운 Activity를 수행하고 현재 Activity를 스텍에서 제거
             startActivity(intent)
         }
+    }
 
-        // 회원가입 하러 가기
+    // 회원가입 하러 가기
+    private fun userClickSignUpBtn() {
         binding.btnSignupSignup.setOnClickListener {
             val intent = Intent(this, SignUpActivity::class.java)
             startActivity(intent)
         }
+    }
 
-        // 로그인 하기
+    // 로그인 하기
+    private fun userCickLoginBtn() {
         binding.btnLoginLogin.setOnClickListener {
             // 자동 로그인이 적용되지 않고, 회원가입에서 넘어온 경우
             val signUpUser = intent.getParcelableExtra<User>("signUpUser")
@@ -84,7 +95,9 @@ class LoginActivity : AppCompatActivity() {
                 }
             }
         }
+    }
 
+    private fun backPressed() {
         val backPressedUtil = BackPressedUtil<ActivityLoginBinding>(this)
         backPressedUtil.BackButton()
     }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginActivity.kt
@@ -20,6 +20,7 @@ import org.sopt.dosopttemplate.presentation.main.BnvActivity
 import org.sopt.dosopttemplate.util.BackPressedUtil
 import org.sopt.dosopttemplate.util.UiState
 import org.sopt.dosopttemplate.util.hideKeyboard
+import org.sopt.dosopttemplate.util.setOnSingleClickListener
 import org.sopt.dosopttemplate.util.showShortSnackBar
 import org.sopt.dosopttemplate.util.showShortToast
 
@@ -52,7 +53,7 @@ class LoginActivity : AppCompatActivity() {
 
     // 회원가입 하러 가기
     private fun userClickSignUpBtn() {
-        binding.btnSignupSignup.setOnClickListener {
+        binding.btnSignupSignup.setOnSingleClickListener {
             val intent = Intent(this, SignUpActivity::class.java)
             startActivity(intent)
         }
@@ -60,7 +61,7 @@ class LoginActivity : AppCompatActivity() {
 
     // 로그인 하기
     private fun userCickLoginBtn() {
-        binding.btnLoginLogin.setOnClickListener {
+        binding.btnLoginLogin.setOnSingleClickListener {
             // 자동 로그인이 적용되지 않고, 회원가입에서 넘어온 경우
             val signUpUser = intent.getParcelableExtra<User>("signUpUser")
 

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
@@ -14,26 +14,21 @@ import org.sopt.dosopttemplate.util.UiState
 
 class LoginViewModel : ViewModel() {
 
-    // 로그인 성공 여부
-    private val _loginResult = MutableLiveData<UiState<Boolean>>()
-    val loginResult: LiveData<UiState<Boolean>> get() = _loginResult
-
     // 로그인 response에서 받아온 유저 정보
     private val _getLoginInfo = MutableLiveData<UiState<User>>()
     val getLoginInfo: LiveData<UiState<User>> get() = _getLoginInfo
 
     fun loginUser(inputId: String, inputPw: String) = viewModelScope.launch {
-        _loginResult.value = UiState.Loading
+        _getLoginInfo.value = UiState.Loading
 
         runCatching {
             ServicePool.authService.login(
                 RequestLoginDto(inputId, inputPw),
             )
         }.onSuccess {
-            _loginResult.value = UiState.Success(true)
             _getLoginInfo.value = UiState.Success(User(it.id.toString(), it.username, it.nickname))
         }.onFailure {
-            _loginResult.value = UiState.Failure(it.message.toString())
+            _getLoginInfo.value = UiState.Failure(it.message.toString())
         }
     }
 

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
@@ -1,10 +1,11 @@
 package org.sopt.dosopttemplate.presentation.auth
 
 import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.User
 import org.sopt.dosopttemplate.data.remote.ServicePool
@@ -15,11 +16,13 @@ import org.sopt.dosopttemplate.util.UiState
 class LoginViewModel : ViewModel() {
 
     // 로그인 response에서 받아온 유저 정보
-    private val _getLoginInfo = MutableLiveData<UiState<User>>()
-    val getLoginInfo: LiveData<UiState<User>> get() = _getLoginInfo
+    private val _getLoginInfo = MutableStateFlow<UiState<User>>(UiState.Initial)
+    val getLoginInfo: StateFlow<UiState<User>> get() = _getLoginInfo
 
     fun loginUser(inputId: String, inputPw: String) = viewModelScope.launch {
         _getLoginInfo.value = UiState.Loading
+        _getLoginInfo.emit(UiState.Loading)
+        delay(SignUpViewModel.refreshMs)
 
         runCatching {
             ServicePool.authService.login(

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
@@ -9,18 +9,18 @@ import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.User
 import org.sopt.dosopttemplate.data.remote.ServicePool
 import org.sopt.dosopttemplate.data.remote.request.RequestLoginDto
-import org.sopt.dosopttemplate.data.remote.response.ResponseLoginDto
 import org.sopt.dosopttemplate.di.UserSharedPreferences
 import org.sopt.dosopttemplate.util.UiState
-import retrofit2.Call
 
 class LoginViewModel : ViewModel() {
     private val _loginResult = MutableLiveData<UiState<Boolean>>()
     val loginResult: LiveData<UiState<Boolean>> get() = _loginResult
 
+    private val _getLoginInfo = MutableLiveData<UiState<User>>()
+    val getLoginInfo: LiveData<UiState<User>> get() = _getLoginInfo
+
     fun loginUser(inputId: String, inputPw: String) = viewModelScope.launch {
         _loginResult.value = UiState.Loading
-        lateinit var getUserInfo: Call<ResponseLoginDto>
 
         runCatching {
             ServicePool.authService.login(
@@ -28,11 +28,11 @@ class LoginViewModel : ViewModel() {
             )
         }.onSuccess {
             // getUserInfo = it
+            _loginResult.value = UiState.Success(true)
+            _getLoginInfo.value = UiState.Success(User(it.id.toString(), it.username, it.nickname))
         }.onFailure {
             _loginResult.value = UiState.Failure(it.message.toString())
         }
-
-        _loginResult.value = UiState.Success(true)
     }
 
     fun saveUserForAutoLogin(context: Context, signUpUser: User) {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/LoginViewModel.kt
@@ -13,9 +13,12 @@ import org.sopt.dosopttemplate.di.UserSharedPreferences
 import org.sopt.dosopttemplate.util.UiState
 
 class LoginViewModel : ViewModel() {
+
+    // 로그인 성공 여부
     private val _loginResult = MutableLiveData<UiState<Boolean>>()
     val loginResult: LiveData<UiState<Boolean>> get() = _loginResult
 
+    // 로그인 response에서 받아온 유저 정보
     private val _getLoginInfo = MutableLiveData<UiState<User>>()
     val getLoginInfo: LiveData<UiState<User>> get() = _getLoginInfo
 
@@ -27,7 +30,6 @@ class LoginViewModel : ViewModel() {
                 RequestLoginDto(inputId, inputPw),
             )
         }.onSuccess {
-            // getUserInfo = it
             _loginResult.value = UiState.Success(true)
             _getLoginInfo.value = UiState.Success(User(it.id.toString(), it.username, it.nickname))
         }.onFailure {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -70,6 +70,10 @@ class SignUpActivity : AppCompatActivity() {
                     is UiState.Loading -> {
                         showShortSnackBar(binding.root, getString(R.string.uistate_loading))
                     }
+
+                    is UiState.Initial -> {
+                        showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                    }
                 }
             }
             binding.btnSignupSignup.setOnClickListener {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -55,6 +55,11 @@ class SignUpActivity : AppCompatActivity() {
     private fun btnEnable() {
         signUpViewModel.signUpBtnFlag()
         binding.btnSignupSignup.isEnabled = signUpViewModel.signUpBtnFlag.value == true
+        if (binding.btnSignupSignup.isEnabled) {
+            signUpViewModel.onUserTextSizeChanged(40)
+        } else {
+            signUpViewModel.onUserTextSizeChanged(10)
+        }
     }
 
     private fun clickSignUpBtn() {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -28,27 +28,16 @@ class SignUpActivity : AppCompatActivity() {
 
     private fun observeValid() {
         signUpViewModel.idFlag.observe(this) { idFlag ->
-            if (idFlag) {
-                binding.telSignupId.error = null
-            } else {
-                binding.telSignupId.error = getString(R.string.id_layout_title)
-            }
+            binding.telSignupId.error = if (idFlag) null else getString(R.string.id_layout_title)
             btnEnable()
         }
         signUpViewModel.pwFlag.observe(this) { pwFlag ->
-            if (pwFlag) {
-                binding.telSignupPw.error = null
-            } else {
-                binding.telSignupPw.error = getString(R.string.pw_layout_title)
-            }
+            binding.telSignupPw.error = if (pwFlag) null else getString(R.string.pw_layout_title)
             btnEnable()
         }
         signUpViewModel.nicknameFlag.observe(this) { nicknameFlag ->
-            if (nicknameFlag) {
-                binding.telSignupNickname.error = null
-            } else {
-                binding.telSignupNickname.error = getString(R.string.nickname_layout_title)
-            }
+            binding.telSignupNickname.error =
+                if (nicknameFlag) null else getString(R.string.nickname_layout_title)
             btnEnable()
         }
     }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.databinding.ActivitySignupBinding
+import org.sopt.dosopttemplate.util.UiState
 import org.sopt.dosopttemplate.util.showShortSnackBar
 import org.sopt.dosopttemplate.util.showShortToast
 
@@ -64,18 +65,26 @@ class SignUpActivity : AppCompatActivity() {
 
     private fun clickSignUpBtn() {
         binding.btnSignupSignup.setOnClickListener {
-            signUpViewModel.signUpUserApi(this)
+            signUpViewModel.signUpResult.observe(this) { uiState ->
+                when (uiState) {
+                    is UiState.Success -> {
+                        showShortToast(getString(R.string.signup_success))
+                        val intent = Intent(this, LoginActivity::class.java)
+                        startActivity(intent)
+                        finish()
+                    }
 
-            signUpViewModel.signUpResult.observe(this) { signUpSuccessful ->
-                if (signUpSuccessful) {
-                    showShortToast(getString(R.string.signup_success))
-                    val intent = Intent(this, LoginActivity::class.java)
-                    // intent.putExtra("signUpUser", signUpUser)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    startActivity(intent)
-                } else {
-                    showShortSnackBar(binding.root, getString(R.string.signup_fail))
+                    is UiState.Failure -> {
+                        showShortSnackBar(binding.root, getString(R.string.signup_fail))
+                    }
+
+                    is UiState.Loading -> {
+                        showShortSnackBar(binding.root, "로딩중")
+                    }
                 }
+            }
+            binding.btnSignupSignup.setOnClickListener {
+                signUpViewModel.signUpUserApi()
             }
         }
     }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.databinding.ActivitySignupBinding
 import org.sopt.dosopttemplate.util.UiState
+import org.sopt.dosopttemplate.util.setOnSingleClickListener
 import org.sopt.dosopttemplate.util.showShortSnackBar
 import org.sopt.dosopttemplate.util.showShortToast
 
@@ -28,7 +29,7 @@ class SignUpActivity : AppCompatActivity() {
         binding.authViewModel = signUpViewModel
 
         observeValid()
-        binding.btnSignupSignup.setOnClickListener {
+        binding.btnSignupSignup.setOnSingleClickListener {
             signUpViewModel.signUpUserApi()
             observeSignUpResult()
         }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -4,7 +4,10 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.databinding.ActivitySignupBinding
@@ -32,19 +35,19 @@ class SignUpActivity : AppCompatActivity() {
     }
 
     private fun observeValid() {
-        signUpViewModel.idFlag.observe(this) { idFlag ->
+        signUpViewModel.idFlag.flowWithLifecycle(lifecycle).onEach { idFlag ->
             binding.telSignupId.error = if (idFlag) null else getString(R.string.id_layout_title)
             btnEnable()
-        }
-        signUpViewModel.pwFlag.observe(this) { pwFlag ->
+        }.launchIn(lifecycleScope)
+        signUpViewModel.pwFlag.flowWithLifecycle(lifecycle).onEach { pwFlag ->
             binding.telSignupPw.error = if (pwFlag) null else getString(R.string.pw_layout_title)
             btnEnable()
-        }
-        signUpViewModel.nicknameFlag.observe(this) { nicknameFlag ->
+        }.launchIn(lifecycleScope)
+        signUpViewModel.nicknameFlag.flowWithLifecycle(lifecycle).onEach { nicknameFlag ->
             binding.telSignupNickname.error =
                 if (nicknameFlag) null else getString(R.string.nickname_layout_title)
             btnEnable()
-        }
+        }.launchIn(lifecycleScope)
     }
 
     private fun btnEnable() {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -75,11 +75,11 @@ class SignUpActivity : AppCompatActivity() {
                     }
 
                     is UiState.Failure -> {
-                        showShortSnackBar(binding.root, getString(R.string.signup_fail))
+                        showShortSnackBar(binding.root, "회원가입 실패 : ${uiState.errorMessage}")
                     }
 
                     is UiState.Loading -> {
-                        showShortSnackBar(binding.root, "로딩중")
+                        showShortSnackBar(binding.root, getString(R.string.uistate_loading))
                     }
                 }
             }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.databinding.ActivitySignupBinding
 import org.sopt.dosopttemplate.util.UiState
@@ -23,7 +25,10 @@ class SignUpActivity : AppCompatActivity() {
         binding.authViewModel = signUpViewModel
 
         observeValid()
-        clickSignUpBtn()
+        binding.btnSignupSignup.setOnClickListener {
+            signUpViewModel.signUpUserApi()
+            observeSignUpResult()
+        }
     }
 
     private fun observeValid() {
@@ -52,15 +57,12 @@ class SignUpActivity : AppCompatActivity() {
         }
     }
 
-    private fun clickSignUpBtn() {
-        binding.btnSignupSignup.setOnClickListener {
-            signUpViewModel.signUpResult.observe(this) { uiState ->
+    private fun observeSignUpResult() {
+        lifecycleScope.launch {
+            signUpViewModel.signUpResult.collect { uiState ->
                 when (uiState) {
                     is UiState.Success -> {
-                        showShortToast(getString(R.string.signup_success))
-                        val intent = Intent(this, LoginActivity::class.java)
-                        startActivity(intent)
-                        finish()
+                        goLogin()
                     }
 
                     is UiState.Failure -> {
@@ -76,9 +78,13 @@ class SignUpActivity : AppCompatActivity() {
                     }
                 }
             }
-            binding.btnSignupSignup.setOnClickListener {
-                signUpViewModel.signUpUserApi()
-            }
         }
+    }
+
+    private fun goLogin() {
+        showShortToast(getString(R.string.signup_success))
+        val intent = Intent(this, LoginActivity::class.java)
+        startActivity(intent)
+        finish()
     }
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpActivity.kt
@@ -78,7 +78,7 @@ class SignUpActivity : AppCompatActivity() {
                     }
 
                     is UiState.Initial -> {
-                        showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                        showShortSnackBar(binding.root, getString(R.string.uistate_initial))
                     }
                 }
             }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.remote.ServicePool
 import org.sopt.dosopttemplate.data.remote.request.RequestSignupDto
@@ -36,7 +37,7 @@ class SignUpViewModel : ViewModel() {
             idFlag.value == true && pwFlag.value == true && nicknameFlag.value == true
     }
 
-    val dynamicTextSize: MutableLiveData<Int> = MutableLiveData(10)
+    val dynamicTextSize: MutableStateFlow<Int> = MutableStateFlow(10)
 
     fun onUserTextSizeChanged(newTextSize: Int) {
         dynamicTextSize.value = newTextSize

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -23,9 +23,9 @@ class SignUpViewModel : ViewModel() {
 
     // 사용자가 입력하는 값들의 유효성 검사, map으로 liveData 관찰하며 연쇄적으로 값이 바뀌도록 함
     val idFlag =
-        inputId.map { it.isNotEmpty() && Pattern.compile(ID_PATTERN).matcher(it).find() }
+        inputId.map { it.isNotEmpty() && ID_REGEX.matcher(it).find() }
     val pwFlag =
-        inputPw.map { it.isNotEmpty() && Pattern.compile(PW_PATTERN).matcher(it).find() }
+        inputPw.map { it.isNotEmpty() && PW_REGEX.matcher(it).find() }
     val nicknameFlag = inputNickname.map { it.isNotEmpty() }
 
     // 버튼 활성화 관찰
@@ -64,7 +64,9 @@ class SignUpViewModel : ViewModel() {
 
     companion object {
         private const val ID_PATTERN = "^(?=.*[A-Za-z])(?=.*[0-9])[A-Za-z[0-9]]{6,10}$"
+        val ID_REGEX: Pattern = Pattern.compile(ID_PATTERN)
         private const val PW_PATTERN =
             "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&.])[A-Za-z[0-9]$@$!%*#?&.]{6,12}$"
+        val PW_REGEX: Pattern = Pattern.compile(PW_PATTERN)
     }
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -1,6 +1,5 @@
 package org.sopt.dosopttemplate.presentation.auth
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
@@ -31,8 +30,9 @@ class SignUpViewModel : ViewModel() {
     val nicknameFlag = inputNickname.map { it.isNotEmpty() }
 
     // 버튼 활성화 관찰
-    private val _signUpBtnFlag: MutableLiveData<Boolean> = MutableLiveData(false)
-    val signUpBtnFlag: LiveData<Boolean> get() = _signUpBtnFlag
+    // TODO : 여기서 버튼 초기값이 false가 되어야 하는데 그 부분이 적용이 안된다.......
+    private val _signUpBtnFlag: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val signUpBtnFlag: StateFlow<Boolean> get() = _signUpBtnFlag.asStateFlow()
 
     fun signUpBtnFlag() {
         _signUpBtnFlag.value =

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -25,10 +25,10 @@ class SignUpViewModel : ViewModel() {
 
     // 사용자가 입력하는 값들의 유효성 검사, map으로 liveData 관찰하며 연쇄적으로 값이 바뀌도록 함
     val idFlag =
-        inputId.map { it.isNotEmpty() && ID_REGEX.matcher(it).find() }
+        inputId.map { (it.isNotEmpty() && ID_REGEX.matcher(it).find()) || it == "" }
     val pwFlag =
-        inputPw.map { it.isNotEmpty() && PW_REGEX.matcher(it).find() }
-    val nicknameFlag = inputNickname.map { it.isNotEmpty() }
+        inputPw.map { (it.isNotEmpty() && PW_REGEX.matcher(it).find()) || it == "" }
+    val nicknameFlag = inputNickname.map { it.isNotEmpty() || it == "" }
 
     // 버튼 활성화 관찰
     private val _signUpBtnFlag: MutableStateFlow<Boolean> = MutableStateFlow(false)

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.remote.ServicePool
 import org.sopt.dosopttemplate.data.remote.request.RequestSignupDto
@@ -13,8 +15,8 @@ import org.sopt.dosopttemplate.util.UiState
 import java.util.regex.Pattern
 
 class SignUpViewModel : ViewModel() {
-    private val _signUpResult = MutableLiveData<UiState<Boolean>>()
-    val signUpResult: LiveData<UiState<Boolean>> get() = _signUpResult
+    private val _signUpResult = MutableStateFlow<UiState<Boolean>>(UiState.Initial)
+    val signUpResult: StateFlow<UiState<Boolean>> get() = _signUpResult.asStateFlow()
 
     // 사용자가 입력하는 값들
     val inputId: MutableLiveData<String> = MutableLiveData()

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -62,7 +62,6 @@ class SignUpViewModel : ViewModel() {
                     inputNickname.value,
                 ),
             )
-            // 여기서 result를 어떻게 처리할지 추가 작업이 필요할 것입니다.
         }.onFailure {
             _signUpResult.emit(UiState.Failure(it.message.toString()))
         }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -42,6 +42,12 @@ class SignUpViewModel : ViewModel() {
             idFlag.value == true && pwFlag.value == true && nicknameFlag.value == true
     }
 
+    val dynamicTextSize: MutableLiveData<Int> = MutableLiveData(10)
+
+    fun onUserTextSizeChanged(newTextSize: Int) {
+        dynamicTextSize.value = newTextSize
+    }
+
     fun signUpUserApi(context: Context) {
         ServicePool.authService.signUp(
             RequestSignupDto(

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -1,12 +1,13 @@
 package org.sopt.dosopttemplate.presentation.auth
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.remote.ServicePool
 import org.sopt.dosopttemplate.data.remote.request.RequestSignupDto
@@ -18,9 +19,9 @@ class SignUpViewModel : ViewModel() {
     val signUpResult: StateFlow<UiState<Boolean>> get() = _signUpResult.asStateFlow()
 
     // 사용자가 입력하는 값들
-    val inputId: MutableLiveData<String> = MutableLiveData()
-    val inputPw: MutableLiveData<String> = MutableLiveData()
-    val inputNickname: MutableLiveData<String> = MutableLiveData()
+    val inputId: MutableStateFlow<String> = MutableStateFlow("")
+    val inputPw: MutableStateFlow<String> = MutableStateFlow("")
+    val inputNickname: MutableStateFlow<String> = MutableStateFlow("")
 
     // 사용자가 입력하는 값들의 유효성 검사, map으로 liveData 관찰하며 연쇄적으로 값이 바뀌도록 함
     val idFlag =
@@ -30,13 +31,17 @@ class SignUpViewModel : ViewModel() {
     val nicknameFlag = inputNickname.map { it.isNotEmpty() }
 
     // 버튼 활성화 관찰
-    // TODO : 여기서 버튼 초기값이 false가 되어야 하는데 그 부분이 적용이 안된다.......
     private val _signUpBtnFlag: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val signUpBtnFlag: StateFlow<Boolean> get() = _signUpBtnFlag.asStateFlow()
 
     fun signUpBtnFlag() {
-        _signUpBtnFlag.value =
-            idFlag.value == true && pwFlag.value == true && nicknameFlag.value == true
+        viewModelScope.launch {
+            combine(idFlag, pwFlag, nicknameFlag) { id, pw, nickname ->
+                id && pw && nickname
+            }.collect { result ->
+                _signUpBtnFlag.value = result
+            }
+        }
     }
 
     val dynamicTextSize: MutableStateFlow<Int> = MutableStateFlow(10)
@@ -46,22 +51,23 @@ class SignUpViewModel : ViewModel() {
     }
 
     fun signUpUserApi() = viewModelScope.launch {
-        _signUpResult.value = UiState.Loading
+        _signUpResult.emit(UiState.Loading) // emit: 결과를 플로우에 방출
+        delay(refreshMs) // 네트워크 요청이 완료될 때까지 중단
 
         runCatching {
             ServicePool.authService.signUp(
                 RequestSignupDto(
-                    inputId.value ?: "",
-                    inputPw.value ?: "",
-                    inputNickname.value ?: "",
+                    inputId.value,
+                    inputPw.value,
+                    inputNickname.value,
                 ),
             )
-        }.onSuccess {
+            // 여기서 result를 어떻게 처리할지 추가 작업이 필요할 것입니다.
         }.onFailure {
-            _signUpResult.value = UiState.Failure(it.message.toString())
+            _signUpResult.emit(UiState.Failure(it.message.toString()))
         }
 
-        _signUpResult.value = UiState.Success(true)
+        _signUpResult.emit(UiState.Success(true))
     }
 
     companion object {
@@ -70,5 +76,6 @@ class SignUpViewModel : ViewModel() {
         private const val PW_PATTERN =
             "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&.])[A-Za-z[0-9]$@$!%*#?&.]{6,12}$"
         val PW_REGEX: Pattern = Pattern.compile(PW_PATTERN)
+        val refreshMs = 2000L
     }
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/auth/SignUpViewModel.kt
@@ -27,10 +27,6 @@ class SignUpViewModel : ViewModel() {
         inputPw.map { it.isNotEmpty() && Pattern.compile(PW_PATTERN).matcher(it).find() }
     val nicknameFlag = inputNickname.map { it.isNotEmpty() }
 
-//    val idFlag: LiveData<Boolean> get() = _idFlag
-//    val pwFlag: LiveData<Boolean> get() = _pwFlag
-//    val nicknameFlag: LiveData<Boolean> get() = _nicknameFlag
-
     // 버튼 활성화 관찰
     private val _signUpBtnFlag: MutableLiveData<Boolean> = MutableLiveData(false)
     val signUpBtnFlag: LiveData<Boolean> get() = _signUpBtnFlag

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListFragment.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListFragment.kt
@@ -60,6 +60,10 @@ class PeopleListFragment : Fragment() {
                 is UiState.Failure -> {
                     showShortSnackBar(binding.root, "정보 불러오기 실패 : ${uiState.errorMessage}")
                 }
+
+                is UiState.Initial -> {
+                    showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                }
             }
         }
 

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListFragment.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListFragment.kt
@@ -6,7 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.databinding.FragmentPeopleListBinding
 import org.sopt.dosopttemplate.presentation.adapter.people.PeopleListAdapter
@@ -43,9 +47,7 @@ class PeopleListFragment : Fragment() {
         binding.rvPeople.layoutManager = LinearLayoutManager(requireContext())
         binding.rvPeople.adapter = peopleListAdapter
 
-        peopleListViewModel.peopleData.observe(
-            viewLifecycleOwner,
-        ) { uiState ->
+        peopleListViewModel.peopleData.flowWithLifecycle(lifecycle).onEach { uiState ->
             when (uiState) {
                 is UiState.Loading -> {
                     showShortSnackBar(binding.root, getString(R.string.uistate_loading))
@@ -62,10 +64,10 @@ class PeopleListFragment : Fragment() {
                 }
 
                 is UiState.Initial -> {
-                    showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                    showShortSnackBar(binding.root, getString(R.string.uistate_initial))
                 }
             }
-        }
+        }.launchIn(lifecycleScope)
 
         peopleListViewModel.fetchPeopleData()
     }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListFragment.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListFragment.kt
@@ -6,10 +6,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
+import org.sopt.dosopttemplate.R
 import org.sopt.dosopttemplate.databinding.FragmentPeopleListBinding
 import org.sopt.dosopttemplate.presentation.adapter.people.PeopleListAdapter
+import org.sopt.dosopttemplate.util.UiState
+import org.sopt.dosopttemplate.util.showShortSnackBar
 
 class PeopleListFragment : Fragment() {
     private val peopleListViewModel by viewModels<PeopleListViewModel>()
@@ -43,13 +45,25 @@ class PeopleListFragment : Fragment() {
 
         peopleListViewModel.peopleData.observe(
             viewLifecycleOwner,
-            Observer { peopleList ->
-                // Log.d("PeopleList 리스트 .. 왜 1개만 보일까융", "list size: ${peopleList.size}")
-                peopleListAdapter.setUsers(ArrayList(peopleList))
-            },
-        )
+        ) { uiState ->
+            when (uiState) {
+                is UiState.Loading -> {
+                    showShortSnackBar(binding.root, getString(R.string.uistate_loading))
+                }
 
-        peopleListViewModel.fetchPeopleData(requireContext())
+                is UiState.Success -> {
+                    showShortSnackBar(binding.root, getString(R.string.uistate_find_friends))
+                    val peopleList = uiState.data
+                    peopleListAdapter.setUsers(ArrayList(peopleList))
+                }
+
+                is UiState.Failure -> {
+                    showShortSnackBar(binding.root, "정보 불러오기 실패 : ${uiState.errorMessage}")
+                }
+            }
+        }
+
+        peopleListViewModel.fetchPeopleData()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListViewModel.kt
@@ -1,44 +1,29 @@
 package org.sopt.dosopttemplate.presentation.main.peoplelist
 
-import android.content.Context
-import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.remote.ServicePool.apiService
 import org.sopt.dosopttemplate.data.remote.response.ResponsePeopleListDto
-import retrofit2.Call
-import retrofit2.Response
+import org.sopt.dosopttemplate.util.UiState
 
 class PeopleListViewModel : ViewModel() {
-    private val _peopleData = MutableLiveData<List<ResponsePeopleListDto>>()
-    val peopleData: LiveData<List<ResponsePeopleListDto>> get() = _peopleData
+    private val _peopleData = MutableLiveData<UiState<List<ResponsePeopleListDto>>>()
+    val peopleData: LiveData<UiState<List<ResponsePeopleListDto>>> get() = _peopleData
 
-    fun fetchPeopleData(context: Context) {
-        apiService.PeopleListGet(2, 6)
-            .enqueue(object : retrofit2.Callback<ResponsePeopleListDto> {
-                override fun onResponse(
-                    call: Call<ResponsePeopleListDto>,
-                    response: Response<ResponsePeopleListDto>,
-                ) {
-                    if (response.isSuccessful) {
-                        _peopleData.value = listOf(response.body() ?: return)
+    fun fetchPeopleData() = viewModelScope.launch {
+        _peopleData.value = UiState.Loading
+        lateinit var peopleList: List<ResponsePeopleListDto>
 
-                        Toast.makeText(
-                            context,
-                            "친구를 찾아봅시다",
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }
-                }
-
-                override fun onFailure(call: Call<ResponsePeopleListDto>, t: Throwable) {
-                    Toast.makeText(
-                        context,
-                        "ㅜ ㅜ 서버 에러 발생 ㅜ ㅜ",
-                        Toast.LENGTH_SHORT,
-                    ).show()
-                }
-            })
+        runCatching {
+            apiService.PeopleListGet(2, 6)
+        }.onSuccess {
+            peopleList = listOf<ResponsePeopleListDto>(it)
+            _peopleData.value = UiState.Success(peopleList)
+        }.onFailure {
+            _peopleData.value = UiState.Failure(it.message.toString())
+        }
     }
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListViewModel.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/presentation/main/peoplelist/PeopleListViewModel.kt
@@ -1,17 +1,18 @@
 package org.sopt.dosopttemplate.presentation.main.peoplelist
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.sopt.dosopttemplate.data.remote.ServicePool.apiService
 import org.sopt.dosopttemplate.data.remote.response.ResponsePeopleListDto
 import org.sopt.dosopttemplate.util.UiState
 
 class PeopleListViewModel : ViewModel() {
-    private val _peopleData = MutableLiveData<UiState<List<ResponsePeopleListDto>>>()
-    val peopleData: LiveData<UiState<List<ResponsePeopleListDto>>> get() = _peopleData
+    private val _peopleData =
+        MutableStateFlow<UiState<List<ResponsePeopleListDto>>>(UiState.Initial)
+    val peopleData: StateFlow<UiState<List<ResponsePeopleListDto>>> get() = _peopleData
 
     fun fetchPeopleData() = viewModelScope.launch {
         _peopleData.value = UiState.Loading

--- a/app/src/main/java/org/sopt/dosopttemplate/util/Extensions.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/util/Extensions.kt
@@ -37,3 +37,17 @@ fun Context.hideKeyboard(view: View) {
     val inputMethodManager = getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
 }
+
+inline fun View.setOnSingleClickListener(
+    delay: Long = 1000L,
+    crossinline block: (View) -> Unit,
+) {
+    var previousClickedTime = 0L
+    setOnClickListener { view ->
+        val clickedTime = System.currentTimeMillis()
+        if (clickedTime - previousClickedTime >= delay) {
+            block(view)
+            previousClickedTime = clickedTime
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/dosopttemplate/util/TextBindingAdapter.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/util/TextBindingAdapter.kt
@@ -1,0 +1,12 @@
+package org.sopt.dosopttemplate.util
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+
+object TextBindingAdapter {
+    @JvmStatic
+    @BindingAdapter("text_ending_word")
+    fun setText(view: TextView, text: String) {
+        view.hint = text + "입력하세요."
+    }
+}

--- a/app/src/main/java/org/sopt/dosopttemplate/util/TextBindingAdapter.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/util/TextBindingAdapter.kt
@@ -4,9 +4,9 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 
 object TextBindingAdapter {
+    @BindingAdapter("dynamicTextSize")
     @JvmStatic
-    @BindingAdapter("text_ending_word")
-    fun setText(view: TextView, text: String) {
-        view.hint = text + "입력하세요."
+    fun setDynamicTextSize(textView: TextView, textSize: Float) {
+        textView.textSize = textSize
     }
 }

--- a/app/src/main/java/org/sopt/dosopttemplate/util/UiState.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/util/UiState.kt
@@ -1,6 +1,8 @@
 package org.sopt.dosopttemplate.util
 
 sealed interface UiState<out T> {
+    object Initial : UiState<Nothing>
+
     object Loading : UiState<Nothing>
 
     data class Success<out T>(

--- a/app/src/main/java/org/sopt/dosopttemplate/util/UiState.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/util/UiState.kt
@@ -1,0 +1,13 @@
+package org.sopt.dosopttemplate.util
+
+sealed interface UiState<out T> {
+    object Loading : UiState<Nothing>
+
+    data class Success<T>(
+        val data: T,
+    ) : UiState<T>
+
+    data class Failure(
+        val errorMessage: String,
+    ) : UiState<Nothing>
+}

--- a/app/src/main/java/org/sopt/dosopttemplate/util/UiState.kt
+++ b/app/src/main/java/org/sopt/dosopttemplate/util/UiState.kt
@@ -3,8 +3,8 @@ package org.sopt.dosopttemplate.util
 sealed interface UiState<out T> {
     object Loading : UiState<Nothing>
 
-    data class Success<T>(
-        val data: T,
+    data class Success<out T>(
+        val data: T? = null,
     ) : UiState<T>
 
     data class Failure(

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -23,6 +23,8 @@
             android:gravity="center"
             android:text="@string/tv_signup_title"
             android:textSize="28sp"
+            dynamicTextSize="@{authViewModel.dynamicTextSize}"
+
             android:textStyle="bold"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="id_layout_title">아이디는 영문, 숫자 포함입니다.</string>
     <string name="pw_layout_title">비밀번호는 영문, 숫자, 특수문자 포함입니다.</string>
     <string name="nickname_layout_title">닉네임은 공백이 불가능합니다.</string>
+    <string name="uistate_loading">로딩 중</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="nickname_layout_title">닉네임은 공백이 불가능합니다.</string>
     <string name="uistate_loading">로딩 중</string>
     <string name="uistate_find_friends">친구를 찾아보아요</string>
+    <string name="uistate_initial">초기 상태</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="pw_layout_title">비밀번호는 영문, 숫자, 특수문자 포함입니다.</string>
     <string name="nickname_layout_title">닉네임은 공백이 불가능합니다.</string>
     <string name="uistate_loading">로딩 중</string>
+    <string name="uistate_find_friends">친구를 찾아보아요</string>
 
 
 </resources>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #21 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- UiState - Initial 상태 추가
- setOnSingleClickListener 추가
- 6주차 심화 과제 코드리뷰 반영
- LiveData -> StateFlow로 변경 (SignUp, Login, People 화면)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


https://github.com/DO-SOPT-ANDROID/yuri-kang/assets/83583757/9c991b83-fe3f-4e08-820e-abaa01a14039


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
LiveData 이었던 것들 모두 stateFlow로 변경하였습니다. 
sharedFlow도 써보고 싶었는데, 제 코드에서는 마땅히 쓸 곳이 없어서 못 써서 아쉽네욥..

**해결하지 못한 고민...이 있는데요**
라이브데이터 때는 초기값이 없어서 문제가 없었는데, stateFlow로 바뀌면서 
inputId, inputPw, inputNickname에 모두 "" 이라는 초기값을 넣어두었습니다. 
그랬더니 회원가입 초기 진입 시 초기값이 "" 이기 때문에 idflag가 false가 되어버려 그때에도 error메시지를 나타나게 되네요

제가 해결하려던 방법은 모두 MutableStateFlow<String?> 로 변경하고 초기값은 null로 하고
널처리를 진행하려고 했는데... 그랬더니 패턴검사를 제대로 못하더라구요.. 

그래서 결론적으로 지금 코드는 
`
val idFlag =
        inputId.map { (it.isNotEmpty() && ID_REGEX.matcher(it).find()) || it == ""}
`
그냥 빈 값일 때도 true가 되도록 임시로 해뒀습니다.....

이렇게 되어도 큰 문제는 없지만 아쉬운 부분이 유저가 아이디를 입력하다가 모두 지운 경우나 회원가입창으로 최초 이동 시 아무값이 없을 때 버튼이 활성화가 되어있다는 것이에요,,
그래서 값을 입력하지 않고 그냥 회원가입 버튼을 누르게 되면 아이디가 ""인 유저가 되어버리져....

결론.. **이 문제는 버튼 활성화 쪽 코드를 바꾸는 게 맞을까요?**

